### PR TITLE
#85: Upgrade to node runtime v20

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 16.x
+      - name: Set Node.js
         uses: actions/setup-node@v3
 
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
 # For environment variables see - https://github.com/neonidian/teams-notify-build-status#environment-variables
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
Tests are failing because of know issue that Microsoft has acknowledged. See [here](https://github.com/neonidian/teams-notify-build-status/issues/84). 