### PR TITLE
Add new View Button for git tag / release

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ See the actions tab in your GitHub repository for runs of this action! :rocket:
 |-----|-----------------------------------|-------------------|---------------|-------------------------------------------------------------------------------------|
 | 1   | SHOULD_DISPLAY_VIEW_RUN_BUTTON    | 'true' or 'false' | false         | Clicking on this button redirects to the attempt of the workflow run page in GitHub |
 | 2   | SHOULD_DISPLAY_VIEW_COMMIT_BUTTON | 'true' or 'false' | false         | Clicking on this button redirects to SHA commit page in GitHub                      |
+| 2   | SHOULD_DISPLAY_VIEW_TAG_BUTTON    | 'true' or 'false' | false         | Clicking on this button redirects to used git tag in GitHub                         |
 | 3   | SHOULD_DISPLAY_ACTOR_LABEL        | 'true' or 'false' | false         | Label to display the username of the workflow initiator                             |
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -75,12 +75,13 @@ See the actions tab in your GitHub repository for runs of this action! :rocket:
 
 ### Environment variables
 
-| #   | Environment variable              | Allowed values    | Default value | Description                                                                         |
-|-----|-----------------------------------|-------------------|---------------|-------------------------------------------------------------------------------------|
-| 1   | SHOULD_DISPLAY_VIEW_RUN_BUTTON    | 'true' or 'false' | false         | Clicking on this button redirects to the attempt of the workflow run page in GitHub |
-| 2   | SHOULD_DISPLAY_VIEW_COMMIT_BUTTON | 'true' or 'false' | false         | Clicking on this button redirects to SHA commit page in GitHub                      |
-| 2   | SHOULD_DISPLAY_VIEW_TAG_BUTTON    | 'true' or 'false' | false         | Clicking on this button redirects to used git tag in GitHub                         |
-| 3   | SHOULD_DISPLAY_ACTOR_LABEL        | 'true' or 'false' | false         | Label to display the username of the workflow initiator                             |
+| #   | Environment variable               | Allowed values    | Default value | Description                                                                         |
+|-----|------------------------------------|-------------------|---------------|-------------------------------------------------------------------------------------|
+| 1   | SHOULD_DISPLAY_VIEW_RUN_BUTTON     | 'true' or 'false' | false         | Clicking on this button redirects to the attempt of the workflow run page in GitHub |
+| 2   | SHOULD_DISPLAY_VIEW_COMMIT_BUTTON  | 'true' or 'false' | false         | Clicking on this button redirects to SHA commit page in GitHub                      |
+| 2   | SHOULD_DISPLAY_VIEW_TAG_BUTTON     | 'true' or 'false' | false         | Clicking on this button redirects to used git tag in GitHub                         |
+| 2   | SHOULD_DISPLAY_VIEW_RELEASE_BUTTON | 'true' or 'false' | false         | Clicking on this button redirects to used release in GitHub                         |
+| 3   | SHOULD_DISPLAY_ACTOR_LABEL         | 'true' or 'false' | false         | Label to display the username of the workflow initiator                             |
 
 ## Examples
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -25638,6 +25638,7 @@ class CustomizeCard {
             SHOULD_DISPLAY_VIEW_RUN_BUTTON,
             SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
             SHOULD_DISPLAY_VIEW_TAG_BUTTON,
+            SHOULD_DISPLAY_VIEW_RELEASE_BUTTON,
             SHOULD_DISPLAY_ACTOR_LABEL,
         } = envs();
         this._messageObject = {
@@ -25746,7 +25747,7 @@ class CustomizeCard {
                                         "type": "Column",
                                         "width": "auto",
                                         "verticalContentAlignment": "center",
-                                        "isVisible": SHOULD_DISPLAY_VIEW_RUN_BUTTON || SHOULD_DISPLAY_VIEW_COMMIT_BUTTON || SHOULD_DISPLAY_VIEW_TAG_BUTTON,
+                                        "isVisible": SHOULD_DISPLAY_VIEW_RUN_BUTTON || SHOULD_DISPLAY_VIEW_COMMIT_BUTTON || SHOULD_DISPLAY_VIEW_TAG_BUTTON || SHOULD_DISPLAY_VIEW_RELEASE_BUTTON,
                                         "items": [
                                             {
                                                 "type": "ActionSet",
@@ -25766,6 +25767,12 @@ class CustomizeCard {
                                                 "actions": SHOULD_DISPLAY_VIEW_TAG_BUTTON ?
                                                     this._constructOpenUrlButton("View tag", this._tagUrl()) : []
                                             },
+                                            {
+                                                "type": "ActionSet",
+                                                "isVisible": SHOULD_DISPLAY_VIEW_RELEASE_BUTTON,
+                                                "actions": SHOULD_DISPLAY_VIEW_RELEASE_BUTTON ?
+                                                    this._constructOpenUrlButton("View release", this._releaseUrl()) : []
+                                            }
                                         ]
                                     }
                                 ]
@@ -25787,6 +25794,10 @@ class CustomizeCard {
 
     _tagUrl() {
         return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF}`;
+    }
+
+    _releaseUrl() {
+        return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/${GITHUB_REF}`;
     }
 
     constructCard() {
@@ -25872,20 +25883,22 @@ const envs = () => {
     const SHOULD_DISPLAY_VIEW_COMMIT_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_COMMIT_BUTTON', false);
     const SHOULD_DISPLAY_ACTOR_LABEL = defineEnvironmentVariable('SHOULD_DISPLAY_ACTOR_LABEL', false);
     const SHOULD_DISPLAY_VIEW_TAG_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_TAG_BUTTON', false);
+    const SHOULD_DISPLAY_VIEW_RELEASE_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_RELEASE_BUTTON', false);
 
     const envVariableNames = [
         SHOULD_DISPLAY_VIEW_RUN_BUTTON,
         SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
         SHOULD_DISPLAY_ACTOR_LABEL,
         SHOULD_DISPLAY_VIEW_TAG_BUTTON,
+        SHOULD_DISPLAY_VIEW_RELEASE_BUTTON,
     ];
 
     // Read env variable values, set to default if value not set
     const allEnvs = {};
     envVariableNames.forEach(envName => {
-            const envElement = process.env[envName[0]];
-            allEnvs[envName[0]] = envElement ? validateEnvVariableName(envName[0], envElement) : envName[1];
-        }
+        const envElement = process.env[envName[0]];
+        allEnvs[envName[0]] = envElement ? validateEnvVariableName(envName[0], envElement) : envName[1];
+    }
     );
 
     // Debug logging

--- a/dist/index.js
+++ b/dist/index.js
@@ -25637,6 +25637,7 @@ class CustomizeCard {
         const {
             SHOULD_DISPLAY_VIEW_RUN_BUTTON,
             SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
+            SHOULD_DISPLAY_VIEW_TAG_BUTTON,
             SHOULD_DISPLAY_ACTOR_LABEL,
         } = envs();
         this._messageObject = {
@@ -25745,7 +25746,7 @@ class CustomizeCard {
                                         "type": "Column",
                                         "width": "auto",
                                         "verticalContentAlignment": "center",
-                                        "isVisible": SHOULD_DISPLAY_VIEW_RUN_BUTTON || SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
+                                        "isVisible": SHOULD_DISPLAY_VIEW_RUN_BUTTON || SHOULD_DISPLAY_VIEW_COMMIT_BUTTON || SHOULD_DISPLAY_VIEW_TAG_BUTTON,
                                         "items": [
                                             {
                                                 "type": "ActionSet",
@@ -25758,6 +25759,12 @@ class CustomizeCard {
                                                 "isVisible": SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
                                                 "actions": SHOULD_DISPLAY_VIEW_COMMIT_BUTTON ?
                                                     this._constructOpenUrlButton("View commit", this._commitUrl()) : []
+                                            },
+                                            {
+                                                "type": "ActionSet",
+                                                "isVisible": SHOULD_DISPLAY_VIEW_TAG_BUTTON,
+                                                "actions": SHOULD_DISPLAY_VIEW_TAG_BUTTON ?
+                                                    this._constructOpenUrlButton("View tag", this._tagUrl()) : []
                                             },
                                         ]
                                     }
@@ -25776,6 +25783,10 @@ class CustomizeCard {
 
     _commitUrl() {
         return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}`;
+    }
+
+    _tagUrl() {
+        return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF}`;
     }
 
     constructCard() {
@@ -25809,6 +25820,7 @@ const {
     GITHUB_RUN_ATTEMPT,
     GITHUB_SHA,
     GITHUB_ACTOR,
+    GITHUB_REF,
 } = process.env;
 
 module.exports = CustomizeCard;
@@ -25859,11 +25871,13 @@ const envs = () => {
     const SHOULD_DISPLAY_VIEW_RUN_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_RUN_BUTTON', false);
     const SHOULD_DISPLAY_VIEW_COMMIT_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_COMMIT_BUTTON', false);
     const SHOULD_DISPLAY_ACTOR_LABEL = defineEnvironmentVariable('SHOULD_DISPLAY_ACTOR_LABEL', false);
+    const SHOULD_DISPLAY_VIEW_TAG_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_TAG_BUTTON', false);
 
     const envVariableNames = [
         SHOULD_DISPLAY_VIEW_RUN_BUTTON,
         SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
         SHOULD_DISPLAY_ACTOR_LABEL,
+        SHOULD_DISPLAY_VIEW_TAG_BUTTON,
     ];
 
     // Read env variable values, set to default if value not set

--- a/src/payload/customize-card/CustomizeCard.js
+++ b/src/payload/customize-card/CustomizeCard.js
@@ -17,6 +17,7 @@ class CustomizeCard {
         const {
             SHOULD_DISPLAY_VIEW_RUN_BUTTON,
             SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
+            SHOULD_DISPLAY_VIEW_TAG_BUTTON,
             SHOULD_DISPLAY_ACTOR_LABEL,
         } = envs();
         this._messageObject = {
@@ -125,7 +126,7 @@ class CustomizeCard {
                                         "type": "Column",
                                         "width": "auto",
                                         "verticalContentAlignment": "center",
-                                        "isVisible": SHOULD_DISPLAY_VIEW_RUN_BUTTON || SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
+                                        "isVisible": SHOULD_DISPLAY_VIEW_RUN_BUTTON || SHOULD_DISPLAY_VIEW_COMMIT_BUTTON || SHOULD_DISPLAY_VIEW_TAG_BUTTON,
                                         "items": [
                                             {
                                                 "type": "ActionSet",
@@ -138,6 +139,12 @@ class CustomizeCard {
                                                 "isVisible": SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
                                                 "actions": SHOULD_DISPLAY_VIEW_COMMIT_BUTTON ?
                                                     this._constructOpenUrlButton("View commit", this._commitUrl()) : []
+                                            },
+                                            {
+                                                "type": "ActionSet",
+                                                "isVisible": SHOULD_DISPLAY_VIEW_TAG_BUTTON,
+                                                "actions": SHOULD_DISPLAY_VIEW_TAG_BUTTON ?
+                                                    this._constructOpenUrlButton("View tag", this._tagUrl()) : []
                                             },
                                         ]
                                     }
@@ -156,6 +163,10 @@ class CustomizeCard {
 
     _commitUrl() {
         return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}`;
+    }
+
+    _tagUrl() {
+        return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF}`;
     }
 
     constructCard() {
@@ -189,6 +200,7 @@ const {
     GITHUB_RUN_ATTEMPT,
     GITHUB_SHA,
     GITHUB_ACTOR,
+    GITHUB_REF,
 } = process.env;
 
 module.exports = CustomizeCard;

--- a/src/payload/customize-card/CustomizeCard.js
+++ b/src/payload/customize-card/CustomizeCard.js
@@ -18,6 +18,7 @@ class CustomizeCard {
             SHOULD_DISPLAY_VIEW_RUN_BUTTON,
             SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
             SHOULD_DISPLAY_VIEW_TAG_BUTTON,
+            SHOULD_DISPLAY_VIEW_RELEASE_BUTTON,
             SHOULD_DISPLAY_ACTOR_LABEL,
         } = envs();
         this._messageObject = {

--- a/src/payload/customize-card/CustomizeCard.js
+++ b/src/payload/customize-card/CustomizeCard.js
@@ -126,7 +126,7 @@ class CustomizeCard {
                                         "type": "Column",
                                         "width": "auto",
                                         "verticalContentAlignment": "center",
-                                        "isVisible": SHOULD_DISPLAY_VIEW_RUN_BUTTON || SHOULD_DISPLAY_VIEW_COMMIT_BUTTON || SHOULD_DISPLAY_VIEW_TAG_BUTTON,
+                                        "isVisible": SHOULD_DISPLAY_VIEW_RUN_BUTTON || SHOULD_DISPLAY_VIEW_COMMIT_BUTTON || SHOULD_DISPLAY_VIEW_TAG_BUTTON || SHOULD_DISPLAY_VIEW_RELEASE_BUTTON,
                                         "items": [
                                             {
                                                 "type": "ActionSet",
@@ -146,6 +146,12 @@ class CustomizeCard {
                                                 "actions": SHOULD_DISPLAY_VIEW_TAG_BUTTON ?
                                                     this._constructOpenUrlButton("View tag", this._tagUrl()) : []
                                             },
+                                            {
+                                                "type": "ActionSet",
+                                                "isVisible": SHOULD_DISPLAY_VIEW_RELEASE_BUTTON,
+                                                "actions": SHOULD_DISPLAY_VIEW_RELEASE_BUTTON ?
+                                                    this._constructOpenUrlButton("View release", this._releaseUrl()) : []
+                                            }
                                         ]
                                     }
                                 ]
@@ -167,6 +173,10 @@ class CustomizeCard {
 
     _tagUrl() {
         return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF}`;
+    }
+
+    _releaseUrl() {
+        return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/${GITHUB_REF}`;
     }
 
     constructCard() {

--- a/src/payload/customize-card/CustomizeCard.js
+++ b/src/payload/customize-card/CustomizeCard.js
@@ -177,9 +177,9 @@ class CustomizeCard {
     }
 
     _releaseUrl() {
-        return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/${GITHUB_REF}`;
+        const tagName = GITHUB_REF.replace(/^refs\/tags\//, '');
+        return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${tagName}`;
     }
-
     constructCard() {
         this._constructJson();
         return this._messageObject;

--- a/src/payload/customize-card/envs.js
+++ b/src/payload/customize-card/envs.js
@@ -6,20 +6,22 @@ const envs = () => {
     const SHOULD_DISPLAY_VIEW_COMMIT_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_COMMIT_BUTTON', false);
     const SHOULD_DISPLAY_ACTOR_LABEL = defineEnvironmentVariable('SHOULD_DISPLAY_ACTOR_LABEL', false);
     const SHOULD_DISPLAY_VIEW_TAG_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_TAG_BUTTON', false);
+    const SHOULD_DISPLAY_VIEW_RELEASE_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_RELEASE_BUTTON', false);
 
     const envVariableNames = [
         SHOULD_DISPLAY_VIEW_RUN_BUTTON,
         SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
         SHOULD_DISPLAY_ACTOR_LABEL,
         SHOULD_DISPLAY_VIEW_TAG_BUTTON,
+        SHOULD_DISPLAY_VIEW_RELEASE_BUTTON,
     ];
 
     // Read env variable values, set to default if value not set
     const allEnvs = {};
     envVariableNames.forEach(envName => {
-            const envElement = process.env[envName[0]];
-            allEnvs[envName[0]] = envElement ? validateEnvVariableName(envName[0], envElement) : envName[1];
-        }
+        const envElement = process.env[envName[0]];
+        allEnvs[envName[0]] = envElement ? validateEnvVariableName(envName[0], envElement) : envName[1];
+    }
     );
 
     // Debug logging

--- a/src/payload/customize-card/envs.js
+++ b/src/payload/customize-card/envs.js
@@ -5,11 +5,13 @@ const envs = () => {
     const SHOULD_DISPLAY_VIEW_RUN_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_RUN_BUTTON', false);
     const SHOULD_DISPLAY_VIEW_COMMIT_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_COMMIT_BUTTON', false);
     const SHOULD_DISPLAY_ACTOR_LABEL = defineEnvironmentVariable('SHOULD_DISPLAY_ACTOR_LABEL', false);
+    const SHOULD_DISPLAY_VIEW_TAG_BUTTON = defineEnvironmentVariable('SHOULD_DISPLAY_VIEW_TAG_BUTTON', false);
 
     const envVariableNames = [
         SHOULD_DISPLAY_VIEW_RUN_BUTTON,
         SHOULD_DISPLAY_VIEW_COMMIT_BUTTON,
         SHOULD_DISPLAY_ACTOR_LABEL,
+        SHOULD_DISPLAY_VIEW_TAG_BUTTON,
     ];
 
     // Read env variable values, set to default if value not set

--- a/src/payload/customize-card/envs.test.js
+++ b/src/payload/customize-card/envs.test.js
@@ -2,12 +2,14 @@ const envs = require('./envs');
 
 describe('Environment variables', () => {
     const SHOULD_DISPLAY_VIEW_COMMIT_BUTTON = "SHOULD_DISPLAY_VIEW_COMMIT_BUTTON";
+    const SHOULD_DISPLAY_VIEW_TAG_BUTTON = "SHOULD_DISPLAY_VIEW_TAG_BUTTON";
     const SHOULD_DISPLAY_VIEW_RUN_BUTTON = "SHOULD_DISPLAY_VIEW_RUN_BUTTON";
     const SHOULD_DISPLAY_ACTOR_LABEL = "SHOULD_DISPLAY_ACTOR_LABEL";
 
     beforeEach(() => {
         delete process.env[SHOULD_DISPLAY_VIEW_COMMIT_BUTTON];
         delete process.env[SHOULD_DISPLAY_VIEW_RUN_BUTTON];
+        delete process.env[SHOULD_DISPLAY_VIEW_TAG_BUTTON];
         delete process.env[SHOULD_DISPLAY_ACTOR_LABEL];
     });
 
@@ -16,6 +18,7 @@ describe('Environment variables', () => {
         expect(response).toMatchObject({
             [SHOULD_DISPLAY_VIEW_COMMIT_BUTTON]: false,
             [SHOULD_DISPLAY_VIEW_RUN_BUTTON]: false,
+            [SHOULD_DISPLAY_VIEW_TAG_BUTTON]: false,
             [SHOULD_DISPLAY_ACTOR_LABEL]: false,
         });
     });
@@ -24,12 +27,14 @@ describe('Environment variables', () => {
         process.env = Object.assign(process.env, {
             [SHOULD_DISPLAY_VIEW_COMMIT_BUTTON]: 'true',
             [SHOULD_DISPLAY_VIEW_RUN_BUTTON]: 'true',
+            [SHOULD_DISPLAY_VIEW_TAG_BUTTON]: 'true',
             [SHOULD_DISPLAY_ACTOR_LABEL]: 'true',
         });
         let response = envs();
         expect(response).toMatchObject({
             [SHOULD_DISPLAY_VIEW_COMMIT_BUTTON]: true,
             [SHOULD_DISPLAY_VIEW_RUN_BUTTON]: true,
+            [SHOULD_DISPLAY_VIEW_TAG_BUTTON]: true,
             [SHOULD_DISPLAY_ACTOR_LABEL]: true,
         });
     });
@@ -58,6 +63,8 @@ describe('Environment variables', () => {
         expect(response).toMatchObject({
             [SHOULD_DISPLAY_VIEW_COMMIT_BUTTON]: true,
             [SHOULD_DISPLAY_VIEW_RUN_BUTTON]: false,
+            [SHOULD_DISPLAY_VIEW_TAG_BUTTON]: false,
+            [SHOULD_DISPLAY_ACTOR_LABEL]: false,
         });
     });
 


### PR DESCRIPTION
Hi, 
We are using this action to notify us on a new release, since we are using GitHub releases, the View commit button is quite useless.
This pull request introduces a View Tag button in the generated card. It can be enabled in the same way the View commit button can be used. 

**Changes**

* Added support for the `SHOULD_DISPLAY_VIEW_TAG_BUTTON` environment variable in `envs.js` and updated its handling throughout the codebase. [[1]](diffhunk://#diff-33c484454fb8143ce16923b9a19ecb30d5333474e3802d9769e56968bd83639dR8-R14) [[2]](diffhunk://#diff-7b7fbab251d3031de10dc6650a8078b61d9aa723ddc105820d20b3f3d6fc77abR5-R12)
* Updated the card rendering logic in `CustomizeCard.js` to conditionally display a "View tag" button, including a new `_tagUrl` method that generates the correct URL for the tag. [[1]](diffhunk://#diff-4a1b867718c441e3c3ff17fed8d298e6372d4cf758937b1474174afcef4ae772R20) [[2]](diffhunk://#diff-4a1b867718c441e3c3ff17fed8d298e6372d4cf758937b1474174afcef4ae772L128-R129) [[3]](diffhunk://#diff-4a1b867718c441e3c3ff17fed8d298e6372d4cf758937b1474174afcef4ae772R143-R148) [[4]](diffhunk://#diff-4a1b867718c441e3c3ff17fed8d298e6372d4cf758937b1474174afcef4ae772R168-R171) [[5]](diffhunk://#diff-4a1b867718c441e3c3ff17fed8d298e6372d4cf758937b1474174afcef4ae772R203)
* Enhanced the environment variable tests in `envs.test.js` to cover the new `SHOULD_DISPLAY_VIEW_TAG_BUTTON` variable, ensuring correct default and explicit values. [[1]](diffhunk://#diff-7b7fbab251d3031de10dc6650a8078b61d9aa723ddc105820d20b3f3d6fc77abR21) [[2]](diffhunk://#diff-7b7fbab251d3031de10dc6650a8078b61d9aa723ddc105820d20b3f3d6fc77abR30-R37) [[3]](diffhunk://#diff-7b7fbab251d3031de10dc6650a8078b61d9aa723ddc105820d20b3f3d6fc77abR66-R67)
* Updated the `README.md` to document the new `SHOULD_DISPLAY_VIEW_TAG_BUTTON` option and its behavior.